### PR TITLE
Enable targetWindow parameter for inter-origin communications

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,6 +25,7 @@ PostMessageStream.prototype._onMessage = function (event) {
 
   // validate message
   if (this._origin !== '*' && event.origin !== this._origin) return
+  if (event.source !== this._targetWindow) return
   if (typeof msg !== 'object') return
   if (msg.target !== this._name) return
   if (!msg.data) return

--- a/index.js
+++ b/index.js
@@ -12,7 +12,8 @@ function PostMessageStream (opts) {
 
   this._name = opts.name
   this._target = opts.target
- 
+  this._targetWindow = opts.targetWindow
+
   window.addEventListener('message', this._onMessage.bind(this), false)
 }
 
@@ -20,13 +21,13 @@ function PostMessageStream (opts) {
 
 PostMessageStream.prototype._onMessage = function (event) {
   var msg = event.data
- 
+
   // validate message
-  if (event.origin !== location.origin) return
+  if (!this._targetWindow && event.origin !== location.origin) return
   if (typeof msg !== 'object') return
   if (msg.target !== this._name) return
   if (!msg.data) return
- 
+
   // forward message
   try {
     this.push(msg.data)
@@ -40,12 +41,14 @@ PostMessageStream.prototype._onMessage = function (event) {
 PostMessageStream.prototype._read = noop
 
 PostMessageStream.prototype._write = function (data, encoding, cb) {
- 
+
   var message = {
     target: this._target,
     data: data,
   }
-  window.postMessage(message, location.origin)
+  var origin = (this._targetWindow) ? '*' : location.origin
+  var targetWindow = this._targetWindow || window
+  targetWindow.postMessage(message, origin)
   cb()
 }
 


### PR DESCRIPTION
Hey there!

I'm integrating MetaMask into Electron using totally isolated, different-origin iframes for security reasons. This change made it necessary for `background <> contentscript` communication without Chrome extension ports.

It just makes it possible to specify a `targetWindow` that the messages will be posted to. Let me know what do you think about it!

Thanks!